### PR TITLE
Fix invalid serialization of hashes in parameters for loner

### DIFF
--- a/lib/resque/plugins/lock_timeout.rb
+++ b/lib/resque/plugins/lock_timeout.rb
@@ -61,7 +61,9 @@ module Resque
       # @param [Array] args job arguments
       # @return [String, nil] job identifier
       def identifier(*args)
-        args.join('-')
+        args.map do |arg|
+          arg.is_a?(Enumerable) ? "[#{identifier(*arg)}]" : arg.to_s
+        end.join('-')
       end
 
       # Override to fully control the redis object used for storing


### PR DESCRIPTION
Loner locking happens on queue time, while parameters still include symbols, while when released they are based on object loaded from JSON which includes only strings. This only affects Hash parameters since `join` converts everything to strings, but if there's a Hash parameter it will be converted AS IS, e.g. "{:a=>3, :c=>3}"

Making conversion recursive to catch nested Hashes.