### PR TITLE
Reduce lock-timeout maximum lock key size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 coverage/
 .rbx/
 .bundle/
+/stdout

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,39 +1,43 @@
+## HEAD
+
+- Fix: ensure exceptions are kept if raised **after** lock timeout expires.
+
 ## 0.4.4 (2014-02-21)
 
-* Add `enqueued?` and `loner_locked?` helper methods.
-* Bump minimum version of resque to v1.22
+- Add: `enqueued?` and `loner_locked?` helper methods.
+- Bump minimum version of resque to v1.22
 
 ## 0.4.1 (2012-11-19)
 
-* Bug fix, allow `@loner` job to be enqueued if timeout expires.
+- Fix: allow `@loner` job to be enqueued if timeout expires.
 
 ## 0.4.0 (2012-11-09)
 
-* Add `@loner` boolean option to prevent job being enqueued if already
+- Add: `@loner` boolean option to prevent job being enqueued if already
   running/enqueued. (Thanks to @ssaunier)
 
 ## 0.3.3 (2012-03-09)
 
-* Tested against v1.20.0 of resque.
+- Tested against v1.20.0 of resque.
 
 ## 0.3.1 (2011-07-16)
 
-* Pass job arguments to `lock_timeout`. (Bob Potter)
-* Added `refresh_lock!` method for long running jobs. (Bob Potter)
+- Pass job arguments to `lock_timeout`. (Bob Potter)
+- Added `refresh_lock!` method for long running jobs. (Bob Potter)
 
 ## 0.3.0 (2011-07-16)
 
-* Ability to customize redis connection used for storing locks.
+- Ability to customize redis connection used for storing locks.
   (thanks Richie Vos =))
-* Added Bundler `Gemfile`.
-* Added abstract stub methods for callback methods:
+- Added Bundler `Gemfile`.
+- Added abstract stub methods for callback methods:
   `lock_failed`, `lock_expired_before_release`
 
 ## 0.2.1 (2010-06-16)
 
-* Relax gemspec dependancies.
+- Relax gemspec dependancies.
 
 ## 0.2.0 (2010-05-05)
 
-* Initial release as `resque-lock-timeout`, forked from Chris Wanstrath'
+- Initial release as `resque-lock-timeout`, forked from Chris Wanstrath'
   `resque-lock`.

--- a/lib/resque/plugins/lock_timeout.rb
+++ b/lib/resque/plugins/lock_timeout.rb
@@ -287,15 +287,13 @@ module Resque
         ensure
           # Release the lock on success and error. Unless a lock_timeout is
           # used, then we need to be more careful before releasing the lock.
-          unless lock_until === true
-            now = Time.now.to_i
-            if lock_until < now
-              # Eeek! Lock expired before perform finished. Trigger callback.
-              lock_expired_before_release(*args)
-              return # dont relase lock.
-            end
+          now = Time.now.to_i
+          if lock_until != true and lock_until < now
+            # Eeek! Lock expired before perform finished. Trigger callback.
+            lock_expired_before_release(*args)
+          else
+            release_lock!(*args)
           end
-          release_lock!(*args)
         end
       end
 

--- a/lib/resque/plugins/lock_timeout.rb
+++ b/lib/resque/plugins/lock_timeout.rb
@@ -114,7 +114,7 @@ module Resque
       #
       # @return [Boolean] true if the job is locked by someone
       def loner_locked?(*args)
-        locked?(*args) || (loner && enqueued?(*args))
+        locked?(*args) || (loner(*args) && enqueued?(*args))
       end
 
       # Convenience method to check if job is locked and lock did not expire.
@@ -169,7 +169,7 @@ module Resque
       #
       # @param [Array] args job arguments
       def before_enqueue_lock(*args)
-        if loner
+        if loner(*args)
           if locked?(*args)
             # Same job is currently running
             loner_enqueue_failed(*args)
@@ -277,7 +277,7 @@ module Resque
         lock_until = acquire_lock!(*args)
 
         # Release loner lock as job has been dequeued
-        release_loner_lock!(*args) if loner
+        release_loner_lock!(*args) if loner(*args)
 
         # Abort if another job holds the lock.
         return unless lock_until

--- a/lib/resque/plugins/lock_timeout.rb
+++ b/lib/resque/plugins/lock_timeout.rb
@@ -61,7 +61,9 @@ module Resque
       # @param [Array] args job arguments
       # @return [String, nil] job identifier
       def identifier(*args)
-        args.join('-')
+        args.map do |arg|
+          arg.is_a?(Enumerable) ? "[#{identifier(*arg)}]" : arg.to_s
+        end.join('-')
       end
 
       # Override to fully control the redis object used for storing

--- a/resque-lock-timeout.gemspec
+++ b/resque-lock-timeout.gemspec
@@ -7,7 +7,6 @@ Gem::Specification.new do |s|
   s.homepage          = 'http://github.com/lantins/resque-lock-timeout'
   s.email             = 'luke@lividpenguin.com'
   s.authors           = ['Luke Antins', 'Ryan Carver', 'Chris Wanstrath']
-  s.has_rdoc          = false
 
   s.files             = %w(README.md Rakefile LICENSE HISTORY.md)
   s.files            += Dir.glob('lib/**/*')

--- a/resque-lock-timeout.gemspec
+++ b/resque-lock-timeout.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob('lib/**/*')
   s.files            += Dir.glob('test/**/*')
 
-  s.add_dependency('resque', '~> 1.22')
+  s.add_dependency('resque', '>= 1.22')
   s.add_development_dependency('rake')
   s.add_development_dependency('minitest', '~> 5.2')
   s.add_development_dependency('yard', '~> 0.8')

--- a/test/lock_test.rb
+++ b/test/lock_test.rb
@@ -225,4 +225,10 @@ class LockTest < Minitest::Test
     Resque.enqueue(LonelyJob)
     assert_equal 1, Resque.size(:test), "Should have enqueued the job"
   end
+
+  def test_exceptions_in_job_after_timeout_should_be_marked_as_failure
+    Resque.enqueue(FailingAfterTimeoutJob)
+    @worker.process
+    assert_equal 1, Resque::Failure.count, "Should have been marked as failure"
+  end
 end

--- a/test/lock_test.rb
+++ b/test/lock_test.rb
@@ -178,6 +178,14 @@ class LockTest < Minitest::Test
     assert !SlowJob.enqueued?, 'no loner lock key should hae been created'
   end
 
+  def test_loner_job_locked_depending_on_args
+    assert Resque.enqueue(LonelyWithArgsJob)
+    assert Resque.enqueue(LonelyWithArgsJob), 'should enqueue if arg not given'
+    assert Resque.enqueue(LonelyWithArgsJob, true)
+    assert !Resque.enqueue(LonelyWithArgsJob, true), 'should not enqueue second job if arg given'
+    assert_equal 3, Resque.size(:test), '3 job should be enqueued'
+  end
+
   def test_loner_job_should_not_be_enqued_if_already_running
     Resque.enqueue(LonelyJob)
     thread = Thread.new { @worker.process }

--- a/test/lock_test.rb
+++ b/test/lock_test.rb
@@ -13,9 +13,11 @@ class LockTest < Minitest::Test
   end
 
   def test_version
-    major, minor, patch = Resque::Version.split('.')
-    assert_equal 1, major.to_i
-    assert minor.to_i >= 7
+    major, minor, patch = Resque::VERSION.split('.')
+    assert_includes [1, 2], major.to_i
+    if major.to_i == 1
+      assert minor.to_i >= 7, 'expect at least Resque 1.7'
+    end
   end
 
   def test_can_acquire_lock

--- a/test/lock_test.rb
+++ b/test/lock_test.rb
@@ -212,6 +212,14 @@ class LockTest < Minitest::Test
     assert_equal 1, $success, 'One job should increment success'
   end
 
+  def test_loner_job_should_fail_quietly_when_enqueued_with_Job_create_while_locked
+    Resque.inline = true
+    LonelyTimeoutJob.acquire_lock!
+    response = Resque::Job.create(:test, LonelyTimeoutJob)
+    Resque.inline = false
+    assert_equal false, response
+  end
+
   def test_loner_job_should_get_enqueued_if_timeout_expired
     Resque.enqueue(LonelyTimeoutExpiringJob)
     thread = Thread.new { @worker.process }

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -158,3 +158,15 @@ class LonelyTimeoutExpiringJob
     sleep 2
   end
 end
+
+# Job that raises an error after its timeout.
+class FailingAfterTimeoutJob
+  extend Resque::Plugins::LockTimeout
+  @queue = :test
+  @lock_timeout = 1
+
+  def self.perform
+    sleep 2
+    raise
+  end
+end

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -147,6 +147,25 @@ class LonelyTimeoutJob
   end
 end
 
+# Exclusive job, but only if run with certain args.
+class LonelyWithArgsJob
+  extend Resque::Plugins::LockTimeout
+  @queue = :test
+
+  def self.loner(lonely=false)
+    lonely
+  end
+
+  def self.perform(*args)
+    $success += 1
+    sleep 0.2
+  end
+
+  def self.loner_enqueue_failed(*args)
+    $enqueue_failed += 1
+  end
+end
+
 # This job won't complete before it's timeout
 class LonelyTimeoutExpiringJob
   extend Resque::Plugins::LockTimeout


### PR DESCRIPTION
It's not critical, as every such key will be added only once and for non-loner lock it will only be added to redis when taken from the queue. But still, why not?