### PR TITLE
Reduce lock-timeout maximum lock key size

### DIFF
--- a/lib/resque/plugins/lock_timeout.rb
+++ b/lib/resque/plugins/lock_timeout.rb
@@ -61,9 +61,10 @@ module Resque
       # @param [Array] args job arguments
       # @return [String, nil] job identifier
       def identifier(*args)
-        args.map do |arg|
+        id = args.map do |arg|
           arg.is_a?(Enumerable) ? "[#{identifier(*arg)}]" : arg.to_s
         end.join('-')
+        id.size > 30 ? Digest::SHA1.base64digest(id) : id
       end
 
       # Override to fully control the redis object used for storing


### PR DESCRIPTION
It's not critical, as every such key will be added only once and for non-loner lock it will only be added to redis when taken from the queue. But still, why not?